### PR TITLE
Save and serialize all style to a local style property.

### DIFF
--- a/save-no-style.js
+++ b/save-no-style.js
@@ -1,0 +1,77 @@
+~function() {
+
+function descend(node, out) {
+  if (node.nodeType == Node.ELEMENT_NODE) {
+    if (node.nodeName == 'STYLE' || node.nodeName == 'SCRIPT')
+      return;
+
+    out.push(node);
+
+    for (var i = 0; i < node.attributes.length; ++i) {
+      if (node.attributes[i].name == 'style')
+        continue;
+      out.attribute(node.attributes[i]);
+    }
+
+    var style = getComputedStyle(node);
+    out.attribute({name: 'style', value: style.cssText});
+
+    var child = node.firstChild;
+    while (child) {
+      descend(child, out);
+      child = child.nextSibling;
+    }
+
+    out.pop();
+  } else if (node.nodeType == Node.COMMENT_NODE) {
+    out.comment(node.textContent);
+  } else if (node.nodeType == Node.TEXT_NODE) {
+    out.text(node.textContent);
+  }
+}
+
+function Recorder() {
+  this.log = [];
+}
+
+Recorder.prototype.base = function(url) {
+  this.log.push({ 't': 'b', 'v': url });
+}
+
+Recorder.prototype.attribute = function(attribute) {
+  this.log.push({ 't': 'a', 'n': attribute.name, 'v': attribute.value });
+}
+
+Recorder.prototype.push = function(node) {
+  this.log.push({ 't': 'n', 'n': node.nodeName });
+}
+
+Recorder.prototype.pop = function() {
+  this.log.push({ 't': '/' });
+}
+
+Recorder.prototype.text = function(text) {
+  this.log.push({ 't': 't', 'v': text })
+}
+
+Recorder.prototype.comment = function(comment) {
+  this.log.push({ 't': 'c', 'v': comment })
+}
+
+Recorder.prototype.save = function() {
+  var blob = new Blob([JSON.stringify(this.log)], { type: 'application/octet-binary' });
+  var blobURL = window.webkitURL.createObjectURL(blob);
+  var link = document.createElement('a');
+  link.href = blobURL;
+  link.download = encodeURIComponent(window.location).replace(/\./g, '-').replace(/\%[0-9A-F]{2}/g, '-') + '.ds.json';
+  link.click();
+}
+
+var recorder = new Recorder();
+
+recorder.base(String(window.location));
+descend(document.documentElement, recorder);
+
+recorder.save();
+
+}();


### PR DESCRIPTION
This makes files around 20x bigger, and DOM instantiation around 10x slower...

I think a filter that reduces the computed style to just the useful parts (i.e. things that are default/non-inherited or different to parent/inherited) would be interesting too.