### PR TITLE
Add Travis Coveralls integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Builder of Tree Builders
 
 [![Build Status](https://travis-ci.org/dglazkov/tree-builder-builder.svg?branch=master)](https://travis-ci.org/dglazkov/tree-builder-builder)
+[![Coverage Status](https://coveralls.io/repos/dglazkov/tree-builder-builder/badge.svg)](https://coveralls.io/r/dglazkov/tree-builder-builder)
 
 ## Quick Start Guide
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp');
 var fs = require('fs');
+var coveralls = require('gulp-coveralls');
 var istanbul = require('gulp-istanbul');
 var mocha = require('gulp-mocha');
 
@@ -32,6 +33,10 @@ function buildTestTask(name, mochaReporter, istanbulReporters) {
         if (istanbulReporters.indexOf('html') !== -1) {
           process.stdout.write('Detailed coverage report at file://' + fs.realpathSync('coverage/index.html') + '\n');
         }
+        if (istanbulReporters.indexOf('lcov') !== -1) {
+          gulp.src('coverage/lcov.info')
+          .pipe(coveralls());
+        }
         cb();
       });
     });
@@ -39,7 +44,7 @@ function buildTestTask(name, mochaReporter, istanbulReporters) {
 }
 
 buildTestTask('test', 'nyan', ['html', 'text-summary']);
-buildTestTask('travis-test', 'spec', ['text', 'text-summary']);
+buildTestTask('travis-test', 'spec', ['lcov', 'text', 'text-summary']);
 
 function buildTask(name, stageList) {
   tasks[name] = stageList;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,7 +35,12 @@ function buildTestTask(name, mochaReporter, istanbulReporters) {
         }
         if (istanbulReporters.indexOf('lcov') !== -1) {
           gulp.src('coverage/lcov.info')
-          .pipe(coveralls());
+          .pipe(coveralls())
+          .on('error', function(err) {
+            console.warn(err);
+            console.warn('Failed to upload LCOV data to Coveralls.')
+            console.warn('Has this repository been enabled for Coveralls tracking? https://coveralls.io/repos/new');
+          });
         }
         cb();
       });

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "chai": "^2.2.0",
     "gulp": "^3.8.11",
+    "gulp-coveralls": "^0.1.4",
     "gulp-istanbul": "^0.10.0",
     "gulp-mocha": "^2.0.0",
     "istanbul": "^0.3.17",


### PR DESCRIPTION
Adds integration with https://coveralls.io to Travis testing for automatic coverage tracking.