### PR TITLE
Remove debug logging when loading files

### DIFF
--- a/core/phase-lib.js
+++ b/core/phase-lib.js
@@ -156,7 +156,6 @@ module.exports.compare = phase({input: typeVar('a'), output: typeVar('a'), arity
 
 module.exports.fileToBuffer = phase({input: types.string, output: types.buffer, arity: '1:1', async: true},
   function(filename, tags) {
-    console.log('reading', filename, 'raw');
     if (!tags.filename) {
       this.tags.tag('filename', filename);
     }


### PR DESCRIPTION
Not sure if we need this log, feel free to close the PR if it's still useful to you.
I'm sad to see nyancat get chopped up by console output when running tests, this change will keep them in one piece.