### PR TITLE
Add command line targeting of experiment nodes

### DIFF
--- a/core/experiment.js
+++ b/core/experiment.js
@@ -44,12 +44,12 @@ function getNodeID(nodeName) {
   return nodeName.slice(i + 1);
 }
 
-function addCommandLineOptions(options, phaseName, nodeID) {
+function addCommandLineOptions(phaseName, nodeID, resultOptions) {
   function addIfKeyPresent(name) {
     if (name in commandLineOptions && typeof commandLineOptions[name] === 'object') {
       console.log(phaseName, nodeID, commandLineOptions[name])
       for (var key in commandLineOptions[name])
-        options[key] = commandLineOptions[name][key];
+        resultOptions[key] = commandLineOptions[name][key];
     }
   }
   addIfKeyPresent(phaseName);

--- a/core/experiment.js
+++ b/core/experiment.js
@@ -22,6 +22,7 @@ var assert = require('chai').assert;
 var Promise = require('bluebird');
 var definePhase = require('./phase-register');
 var path = require('path');
+var commandLineOptions = require('./options');
 
 function getPhaseName(nodeName, options) {
   var phaseName = nodeName;
@@ -36,10 +37,31 @@ function getPhaseName(nodeName, options) {
   return phaseName;
 }
 
+function getNodeID(nodeName) {
+  var i = nodeName.indexOf('_');
+  if (i === -1)
+    return null;
+  return nodeName.slice(i + 1);
+}
+
+function addCommandLineOptions(options, phaseName, nodeID) {
+  function addIfKeyPresent(name) {
+    if (name in commandLineOptions && typeof commandLineOptions[name] === 'object') {
+      console.log(phaseName, nodeID, commandLineOptions[name])
+      for (var key in commandLineOptions[name])
+        options[key] = commandLineOptions[name][key];
+    }
+  }
+  addIfKeyPresent(phaseName);
+  addIfKeyPresent(nodeID);
+}
+
 function mkPhase(nodeName, inGraph) {
   var options = inGraph.node(nodeName) || {};
   options.id = nodeName;
   var phaseName = getPhaseName(nodeName, options);
+  var nodeID = getNodeID(nodeName);
+  addCommandLineOptions(options, phaseName, nodeID);
   var result = new graph.Pipe(phaseName, options);
   result.nodeName = nodeName;
   return result;

--- a/core/experiment.js
+++ b/core/experiment.js
@@ -45,11 +45,10 @@ function getNodeID(nodeName) {
 }
 
 function addCommandLineOptions(phaseName, nodeID, resultOptions) {
-  function addIfKeyPresent(name) {
-    if (name in commandLineOptions && typeof commandLineOptions[name] === 'object') {
-      console.log(phaseName, nodeID, commandLineOptions[name])
-      for (var key in commandLineOptions[name])
-        resultOptions[key] = commandLineOptions[name][key];
+  function addIfKeyPresent(key) {
+    if (key in commandLineOptions && typeof commandLineOptions[key] === 'object') {
+      for (var innerKey in commandLineOptions[key])
+        resultOptions[innerKey] = commandLineOptions[key][innerKey];
     }
   }
   addIfKeyPresent(phaseName);
@@ -61,7 +60,7 @@ function mkPhase(nodeName, inGraph) {
   options.id = nodeName;
   var phaseName = getPhaseName(nodeName, options);
   var nodeID = getNodeID(nodeName);
-  addCommandLineOptions(options, phaseName, nodeID);
+  addCommandLineOptions(phaseName, nodeID, options);
   var result = new graph.Pipe(phaseName, options);
   result.nodeName = nodeName;
   return result;

--- a/core/phase-lib.js
+++ b/core/phase-lib.js
@@ -155,6 +155,14 @@ module.exports.compare = phase({input: typeVar('a'), output: typeVar('a'), arity
   },
   { tag: ''});
 
+module.exports.compareString = phase({input: types.string, output: types.string, arity: '1:1'},
+  function(input) {
+    var assert = require('chai').assert;
+    assert.equal(input, this.options.data);
+    return input;
+  },
+  {data: ''});
+
 module.exports.fileToBuffer = phase({input: types.string, output: types.buffer, arity: '1:1', async: true},
   function(filename, tags) {
     if (!tags.filename) {

--- a/tests/experiment-command-line-options.js
+++ b/tests/experiment-command-line-options.js
@@ -1,0 +1,50 @@
+/*
+  Copyright 2015 Google Inc. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+var stageLoader = require('../core/stage-loader');
+// TODO: Make command line options a parameter to running an experiment so we can test them in isolation.
+var options = require('../core/options');
+
+function runExperiment(experiment, cb) {
+  var stageList = [{name: 'input', options: {data: experiment}}, 'doExperiment'].map(stageLoader.stageSpecificationToStage);
+  stageLoader.processStages(stageList, cb, function(e) { throw e; });
+};
+
+describe('Experiment command line options', function() {
+  it('should be able to target node IDs', function(done) {
+    options.targetNodeID = {data: 'test input'};
+    var experiment =
+        'digraph experiment {' +
+        '  compareString_withData [data="test input"];' +
+        '  compareString_withoutData [data=""];' +
+        '  input_targetNodeID -> compareString_withData;' +
+        '  input_untargeted -> compareString_withoutData;' +
+        '}';
+    runExperiment(experiment, done);
+  });
+  it('should be able to target phases', function(done) {
+    var oldInput = options.input;
+    options.input = {data: 'test input'};
+    var experiment =
+        'digraph experiment {' +
+        '  compareString [data="test input"];' +
+        '  input_a -> compareString;' +
+        '  input_b -> compareString;' +
+        '}';
+    runExperiment(experiment, function() {
+      options.input = oldInput;
+      done();
+    });
+  });
+});
+


### PR DESCRIPTION
This change allows you to set experiment node options via the command line.
It supports two forms: `--<phase name>.<option>=<value>` and `--<node ID>.<option>=<value>`.
Example: `--input.data="test"`.
