### PR TITLE
Add command line option aliasing for experiments

### DIFF
--- a/tests/experiment-command-line-options.js
+++ b/tests/experiment-command-line-options.js
@@ -46,5 +46,38 @@ describe('Experiment command line options', function() {
       done();
     });
   });
+  it('should support node ID aliasing', function(done) {
+    options.testNodeIDAlias = 'test input';
+    var experiment =
+        'digraph experiment {' +
+        '  optionAliases="testNodeIDAlias=nodeID.data";' +
+        '  compareString [data="test input"];' +
+        '  input_nodeID -> compareString;' +
+        '}';
+    runExperiment(experiment, done);
+  });
+  it('should support phase aliasing', function(done) {
+    options.testPhaseAlias = 'test input';
+    var experiment =
+        'digraph experiment {' +
+        '  optionAliases="testPhaseAlias=input.data";' +
+        '  compareString [data="test input"];' +
+        '  input -> compareString;' +
+        '}';
+    runExperiment(experiment, done);
+  });
+  it('should support multiple aliases', function(done) {
+    options.testAliasA = 'test input A';
+    options.testAliasB = 'test input B';
+    var experiment =
+        'digraph experiment {' +
+        '  optionAliases="testAliasA=nodeA.data, testAliasB=nodeB.data";' +
+        '  compareString_a [data="test input A"];' +
+        '  compareString_b [data="test input B"];' +
+        '  input_nodeA -> compareString_a;' +
+        '  input_nodeB -> compareString_b;' +
+        '}';
+    runExperiment(experiment, done);
+  });
 });
 


### PR DESCRIPTION
This change adds an `optionAliases` attribute to experiment files that takes comma separated values of the form `<alias>=<phase name or node ID>.<option>`.
This allows experiments to provide a simpler interface to command line options than using specific node names.
Example: `optionAliases="file=file.data, output=writeStringFile.filename";`