### PR TITLE
Convert the html task into an experiment

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,6 @@ var options = require('./core/options');
 var trace = require('./core/trace');
 
 var tasks = {};
-var experimentFiles = [];
 
 function runTests(mochaReporter) {
   return gulp.src(['tests/*.js', 'tests/pipeline/*.js', 'lib/*/tests/*.js'])
@@ -82,15 +81,10 @@ function buildTask(name, stageList) {
   });
 };
 
-function buildExperimentTask(name, experimentFile) {
-  experimentFiles.push(experimentFile);
-  buildTask(name, [{name: 'input', options: {data: experimentFile}}, 'fileToBuffer', 'bufferToString', 'doExperiment']);
-};
-
 /*
  * Some example pipelines.
  */
-buildExperimentTask('html', 'tasks/html.exp');
+buildTask('html', [{name: 'input', options: {data: 'tasks.erlnmyr'}}, 'fileToBuffer', 'bufferToString', 'doExperiment']);
 buildTask('js', [{name: 'input', options: {data: options.file}}, 'fileToBuffer', 'bufferToString', 'jsonParse', 'JSWriter', {name: 'writeStringFile', options: {filename: 'result.js.html'}}]);
 buildTask('stats', [{name: 'input', options: {data: options.file}}, 'fileToBuffer', 'bufferToString', 'jsonParse', 'StatsWriter', 'log']);
 
@@ -178,4 +172,3 @@ gulp.task('processLogs', function(incb) {
 });
 
 module.exports.tasks = tasks;
-module.exports.experimentFiles = experimentFiles;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,6 +23,7 @@ var options = require('./core/options');
 var trace = require('./core/trace');
 
 var tasks = {};
+var experimentFiles = [];
 
 function runTests(mochaReporter) {
   return gulp.src(['tests/*.js', 'tests/pipeline/*.js', 'lib/*/tests/*.js'])
@@ -81,10 +82,15 @@ function buildTask(name, stageList) {
   });
 };
 
+function buildExperimentTask(name, experimentFile) {
+  experimentFiles.push(experimentFile);
+  buildTask(name, [{name: 'input', options: {data: experimentFile}}, 'fileToBuffer', 'bufferToString', 'doExperiment']);
+};
+
 /*
  * Some example pipelines.
  */
-buildTask('html', [{name: 'input', options: {data: options.file}}, 'fileToBuffer', 'bufferToString', 'jsonParse', 'HTMLWriter', {name: 'writeStringFile', options: {filename: 'result.html.html'}}]);
+buildExperimentTask('html', 'tasks/html.exp');
 buildTask('js', [{name: 'input', options: {data: options.file}}, 'fileToBuffer', 'bufferToString', 'jsonParse', 'JSWriter', {name: 'writeStringFile', options: {filename: 'result.js.html'}}]);
 buildTask('stats', [{name: 'input', options: {data: options.file}}, 'fileToBuffer', 'bufferToString', 'jsonParse', 'StatsWriter', 'log']);
 
@@ -172,3 +178,4 @@ gulp.task('processLogs', function(incb) {
 });
 
 module.exports.tasks = tasks;
+module.exports.experimentFiles = experimentFiles;

--- a/tasks.erlnmyr
+++ b/tasks.erlnmyr
@@ -1,4 +1,4 @@
-digraph experiment {
+digraph html {
   optionAliases="file=input.data";
   writeStringFile [filename="result.html.html"];
 

--- a/tasks/html.exp
+++ b/tasks/html.exp
@@ -1,0 +1,6 @@
+digraph experiment {
+  optionAliases="file=input.data";
+  writeStringFile [filename="result.html.html"];
+
+  input -> fileToBuffer -> bufferToString -> jsonParse -> HTMLWriter -> writeStringFile;
+}

--- a/tests/gulpfile.js
+++ b/tests/gulpfile.js
@@ -13,16 +13,34 @@
 
 var assert = require('chai').assert;
 
+var Promise = require('bluebird');
 var tasks = require('../gulpfile').tasks;
+var experimentFiles = require('../gulpfile').experimentFiles;
 var stageLoader = require('../core/stage-loader');
 var stream = require('../core/stream');
 
 describe('basicTargetCoverage', function() {
   it('should be possible to at least type check the targets listed in gulpfile', function() {
-    for (name in tasks) {
+    for (var name in tasks) {
       var stageList = tasks[name].map(stageLoader.stageSpecificationToStage);
       stageLoader.typeCheck(stageList);
     }
+  });
+
+  it('should be possible to at least type check the experiment targets listed in gulpfile', function(done) {
+    Promise.all(experimentFiles.map(function(experimentFile) {
+      return new Promise(function(resolve, reject) {
+        var stageList = [
+          {name: 'input', options: {data: experimentFile}},
+          'fileToBuffer',
+          'bufferToString',
+          'typeCheckExperiment',
+        ];
+        stageLoader.processStages(stageList.map(stageLoader.stageSpecificationToStage), resolve, reject);
+      });
+    })).then(function() {
+      done();
+    }).catch(done);
   });
 
   // TODO: Once stage-loader has string names for all the fancy stages, roll the special gulpfile targets

--- a/tests/gulpfile.js
+++ b/tests/gulpfile.js
@@ -13,9 +13,7 @@
 
 var assert = require('chai').assert;
 
-var Promise = require('bluebird');
 var tasks = require('../gulpfile').tasks;
-var experimentFiles = require('../gulpfile').experimentFiles;
 var stageLoader = require('../core/stage-loader');
 var stream = require('../core/stream');
 
@@ -27,20 +25,14 @@ describe('basicTargetCoverage', function() {
     }
   });
 
-  it('should be possible to at least type check the experiment targets listed in gulpfile', function(done) {
-    Promise.all(experimentFiles.map(function(experimentFile) {
-      return new Promise(function(resolve, reject) {
-        var stageList = [
-          {name: 'input', options: {data: experimentFile}},
-          'fileToBuffer',
-          'bufferToString',
-          'typeCheckExperiment',
-        ];
-        stageLoader.processStages(stageList.map(stageLoader.stageSpecificationToStage), resolve, reject);
-      });
-    })).then(function() {
-      done();
-    }).catch(done);
+  it('should be possible to at least type check the tasks.erlnmyr file', function(done) {
+    var stageList = [
+      {name: 'input', options: {data: 'tasks.erlnmyr'}},
+      'fileToBuffer',
+      'bufferToString',
+      'typeCheckExperiment',
+    ];
+    stageLoader.processStages(stageList.map(stageLoader.stageSpecificationToStage), done, function(error) { throw error; });
   });
 
   // TODO: Once stage-loader has string names for all the fancy stages, roll the special gulpfile targets


### PR DESCRIPTION
This change adds the necessary pieces to be able to convert many of our Gulp tasks over to experiments. This converts the `html` task over as proof of implementation.