### PR TITLE
Perf on android for Erlenmeyer

### DIFF
--- a/device-perf.erlnmyr
+++ b/device-perf.erlnmyr
@@ -4,5 +4,5 @@ digraph device {
   input -> browser -> startTracing -> load -> endTracing -> closeBrowser;
 
   input [data="http://www.nytimes.com"];
-  browser [browser="android-chromium"];
+  browser [browser="android-chromium", perf="true"];
 }

--- a/device-perf.erlnmyr
+++ b/device-perf.erlnmyr
@@ -1,0 +1,8 @@
+digraph device {
+  imports="['browser-phases']";
+
+  input -> browser -> startTracing -> load -> endTracing -> closeBrowser;
+
+  input [data="http://www.nytimes.com"];
+  browser [browser="android-chromium"];
+}

--- a/lib/device-phases.js
+++ b/lib/device-phases.js
@@ -59,7 +59,13 @@ function _telemetryTask(pyScript, pyArgs) {
 }
 
 function BrowserWrapper(url, options, resolve) {
-  this.task = spawn('python', ['telemetry/newBrowser.py', '--browser=' + options.browser, '--', '--disable-web-security', '--chromium', chromium_path]);
+  console.log(options);
+  var cmd = ['telemetry/newBrowser.py', '--browser=' + options.browser, '--chromium', chromium_path];
+  if (options.perf) {
+    cmd.push('--perf');
+  }
+  cmd.push('--', '--disable-web-security' );
+  this.task = spawn('python', cmd);
   this.url = url;
   this.data = undefined;
   this.processResult = this.defaultProcessResult;
@@ -102,7 +108,6 @@ BrowserWrapper.prototype = {
     return this.waitForOK();
   },
   startTracing: function() {
-    console.log('startTracing');
     this.task.stdin.write('startTracing\n');
     return this.waitForOK();
   },

--- a/lib/device-phases.js
+++ b/lib/device-phases.js
@@ -31,7 +31,7 @@ function expandPath(p) {
 
 // update PYTHONPATH for all telemetry invocations
 if (options.chromium !== undefined) {
-  var chromium_path = expandPath(options.chromium);
+  chromium_path = expandPath(options.chromium);
   console.log("chromium path=%s", chromium_path);
   process.env.PYTHONPATH += path.delimiter + chromium_path + '/tools/telemetry';
   process.env.PYTHONPATH += path.delimiter + chromium_path + '/tools';
@@ -59,7 +59,7 @@ function _telemetryTask(pyScript, pyArgs) {
 }
 
 function BrowserWrapper(url, options, resolve) {
-  this.task = spawn('python', ['telemetry/newBrowser.py', '--browser=' + options.browser, '--', '--disable-web-security']);
+  this.task = spawn('python', ['telemetry/newBrowser.py', '--browser=' + options.browser, '--', '--disable-web-security', '--chromium', chromium_path]);
   this.url = url;
   this.data = undefined;
   this.processResult = this.defaultProcessResult;
@@ -220,7 +220,7 @@ module.exports.browser = phase({input: types.string, output: types.Browser(types
         return new BrowserWrapper(url, options, resolveEnd);
       });
     },
-    {browser: 'android-chromium', perf: true, chrome_categories: 'blink,cc'});
+    {browser: 'android-chromium', perf: false});
 
 function typeVar(s) { return function(v) {
   if (!v[s]) {

--- a/lib/device-phases.js
+++ b/lib/device-phases.js
@@ -34,6 +34,7 @@ if (options.chromium !== undefined) {
   var chromium_path = expandPath(options.chromium);
   console.log("chromium path=%s", chromium_path);
   process.env.PYTHONPATH += path.delimiter + chromium_path + '/tools/telemetry';
+  process.env.PYTHONPATH += path.delimiter + chromium_path + '/tools';
 }
 
 function telemetryTask(pyScript, pyArgs) {
@@ -219,7 +220,7 @@ module.exports.browser = phase({input: types.string, output: types.Browser(types
         return new BrowserWrapper(url, options, resolveEnd);
       });
     },
-    {browser: 'system'});
+    {browser: 'android-chromium', perf: true, chrome_categories: 'blink,cc'});
 
 function typeVar(s) { return function(v) {
   if (!v[s]) {

--- a/telemetry/newBrowser.py
+++ b/telemetry/newBrowser.py
@@ -104,8 +104,9 @@ with browserFactory.Create(options) as browser:
       f.flush();
 
       if options.perf:
+        sys.stderr.write('Downloading perf data and symbols from device...')
         perf_data = browser.profiling_controller.Stop();
-        sys.stderr.write('Converting Perf profiles to JSON\n')
+        sys.stderr.write('Converting perf data to JSON\n')
         json_perf_data = [convertPerfProfileToJSON(i) for i in perf_data]
         json_perf_data = [i for i in json_perf_data if i is not None]
 

--- a/telemetry/newBrowser.py
+++ b/telemetry/newBrowser.py
@@ -98,8 +98,8 @@ with browserFactory.Create(options) as browser:
       sys.stdout.flush();
     elif command.startswith('endTracing'):
       sys.stderr.write('EndTrace\n');
-      f = tempfile.NamedTemporaryFile();
       data = browser.platform.tracing_controller.Stop();
+      f = tempfile.NamedTemporaryFile();
       data.Serialize(f);
       f.flush();
 
@@ -119,7 +119,6 @@ with browserFactory.Create(options) as browser:
         sys.stderr.write("Trace written to file://%s" % os.path.abspath(combined))
 
       command = sys.stdin.readline()[:-1];
-      sys.stderr.write('Command now is ' + command);
       assert command == 'done';
       f.close();
     elif command.startswith('exec:'):

--- a/telemetry/newBrowser.py
+++ b/telemetry/newBrowser.py
@@ -12,6 +12,8 @@
  # See the License for the specific language governing permissions and
  # limitations under the License
 
+# To run erlnmyr
+# ./erlnmyr test.erlnmyr --chromium=~/chromium-android/src
 import sys
 import os
 import subprocess
@@ -24,42 +26,47 @@ from telemetry.timeline import tracing_category_filter
 from telemetry.timeline import tracing_options
 
 from profile_chrome import trace_packager
+from telemetry.internal.platform import device_finder
 
 from json import dumps
 
 import tempfile
 
-# import optionParser
-
 options = browser_options.BrowserFinderOptions();
-options.extra_browser_args_as_string = '--single-process --no-sandbox'
 parser = options.CreateParser();
+parser.add_option('-c', '--chromium', help='Directory for chromium src folder to use for binaries')
+parser.add_option('-p', '--perf', help='Collect perf traces', action='store_true')
 (_, args) = parser.parse_args();
 cwd = os.getcwd()
-import os
-os.chdir('/usr/local/google/home/soonm/chromium-android/src')
+
+if options.perf:
+  options.AppendExtraBrowserArgs([
+    '--no-sandbox',
+    '--allow-sandbox-debugging',
+    '--single-process'
+  ])
+  os.chdir(options.chromium)
+  options.profiler = 'perf';
 
 browserFactory = browser_finder.FindBrowser(options);
 
 def convertPerfProfileToJSON(perf_profile):
-    sys.stderr.write('writing ' + perf_profile + ' to json\n')
-    perfhost_path = '/usr/local/google/home/soonm/chromium-android/src/tools/telemetry/bin/linux/x86_64/perfhost_trusty'
-    perf_script_path = '/usr/local/google/home/soonm/chromium-android/src/tools/profile_chrome/third_party/perf_to_tracing.py'
-    symfs_dir = '/tmp/erlnmyr-perf/'
-    kallsyms = '/tmp/erlnmyr-perf/kallsyms'
-    json_file_name = os.path.basename(perf_profile)
-    sys.stderr.write(json_file_name)
-    with open(os.devnull, 'w') as dev_null, \
-        open(json_file_name, 'w') as json_file:
-      cmd = [perfhost_path, 'script', '-s', perf_script_path, '-i',
-             perf_profile, '--symfs', symfs_dir, '--kallsyms', kallsyms]
+  sys.stderr.write('Writing ' + perf_profile + ' to json\n')
+  perfhost_path = os.path.join(options.chromium, 'tools', 'telemetry', 'bin', 'linux', 'x86_64', 'perfhost_trusty')
+  perf_script_path = os.path.join(options.chromium, 'tools', 'profile_chrome', 'third_party', 'perf_to_tracing.py')
 
-      if subprocess.call(cmd, stdout=json_file, stderr=sys.stderr):
-        sys.stderr.write('Perf data to JSON conversion failed. The result will '
-                        'not contain any perf samples. You can still view the '
-                        'perf data manually as shown above.')
-        return None
-    return json_file_name
+  symfs_dir = '/tmp/erlnmyr-perf/'
+  kallsyms = '/tmp/erlnmyr-perf/kallsyms'
+  json_file_name = os.path.basename(perf_profile)
+  with open(os.devnull, 'w') as dev_null, open(json_file_name, 'w') as json_file:
+    cmd = [perfhost_path, 'script', '-s', perf_script_path, '-i',
+           perf_profile, '--symfs', symfs_dir, '--kallsyms', kallsyms]
+
+    if subprocess.call(cmd, stdout=json_file, stderr=dev_null):
+      sys.stderr.write('Perf data to JSON conversion failed. The result will '
+                      'not contain any perf samples.')
+      return None
+  return json_file_name
 
 with browserFactory.Create(options) as browser:
   tab = browser.tabs.New();
@@ -72,6 +79,7 @@ with browserFactory.Create(options) as browser:
   while True:
     command = sys.stdin.readline()[:-1];
     if command == 'exit':
+      sys.stderr.write('Close Browser\n');
       break
     elif command.startswith('load:'):
       url = command[5:]
@@ -81,28 +89,36 @@ with browserFactory.Create(options) as browser:
       sys.stdout.flush();
     elif command.startswith('startTracing'):
       category_filter = tracing_category_filter.TracingCategoryFilter()
-      options = tracing_options.TracingOptions()
-      options.enable_chrome_trace = True
-      browser.platform.tracing_controller.Start(options, category_filter);
-      browser.profiling_controller.Start('perf', '/tmp/erlnmyr-perf/profiling-results');
+      tracing_options = tracing_options.TracingOptions()
+      tracing_options.enable_chrome_trace = True
+      browser.platform.tracing_controller.Start(tracing_options, category_filter);
+      if options.perf:
+        browser.profiling_controller.Start('perf', '/tmp/erlnmyr-perf/profiling-results');
       sys.stdout.write('OK');
       sys.stdout.flush();
     elif command.startswith('endTracing'):
       sys.stderr.write('EndTrace\n');
-      data = browser.platform.tracing_controller.Stop();
-      result = browser.profiling_controller.Stop();
-      sys.stderr.write('Results : ' + str(result));
-      json_result = [convertPerfProfileToJSON(i) for i in result]
       f = tempfile.NamedTemporaryFile();
+      data = browser.platform.tracing_controller.Stop();
       data.Serialize(f);
       f.flush();
-      sys.stderr.write('final files : ' + str(json_result))
-      sys.stdout.write(f.name + '\n');
-      sys.stdout.flush();
-      json_result.append(f.name)
-      combined = trace_packager.PackageTraces(json_result, output=cwd+'/final-form', compress=False, write_json=False)
-      sys.stderr.write("Trace written to file://%s" % os.path.abspath(combined))
+
+      if options.perf:
+        perf_data = browser.profiling_controller.Stop();
+        sys.stderr.write('Converting Perf profiles to JSON\n')
+        json_perf_data = [convertPerfProfileToJSON(i) for i in perf_data]
+        json_perf_data = [i for i in json_perf_data if i is not None]
+
+        json_perf_data.append(f.name)
+
+        merged_profile = tempfile.NamedTemporaryFile();
+        output = os.path.join(tempfile.tempdir, merged_profile.name)
+        sys.stderr.write('Merging Traces\n')
+        combined = trace_packager.PackageTraces(json_perf_data, output=output, compress=False, write_json=False)
+        sys.stderr.write("Trace written to file://%s" % os.path.abspath(combined))
+
       command = sys.stdin.readline()[:-1];
+      sys.stderr.write('Command now is ' + command);
       assert command == 'done';
       f.close();
     elif command.startswith('exec:'):


### PR DESCRIPTION
To test,
erlnmyr device-perf.erlnmyr --chromium=~/chromium/src

Still waiting for https://code.google.com/p/chromium/issues/detail?id=514465 to be resolved. Without --raw-samples, I don't think I can see the samples on about:tracing,

To test this you can physically apply this to your chromium/src

diff --git a/tools/telemetry/telemetry/internal/platform/profiler/perf_profiler.py b/tools/telemetry/telemetry/internal/platform/profiler/perf_profiler.py
index 835e9f9..22c5133 100644
--- a/tools/telemetry/telemetry/internal/platform/profiler/perf_profiler.py
+++ b/tools/telemetry/telemetry/internal/platform/profiler/perf_profiler.py
@@ -28,6 +28,7 @@ _PERF_OPTIONS = [
     '-g',
     # Increase sampling frequency for better coverage.
     '--freq', '2000',
+    '--raw-samples'
 ]
 
 _PERF_OPTIONS_ANDROID = [


